### PR TITLE
importer: fix frontmatter md dates not imported properly

### DIFF
--- a/packages/core/__tests__/data/md/md-with-frontmatter.md
+++ b/packages/core/__tests__/data/md/md-with-frontmatter.md
@@ -3,6 +3,8 @@ title: A beautiful morning
 tags: wonderful,journal
 pinned: true
 favorite: true
+created_at: 2013-06-06T09:00:00.001Z
+updated_at: 2014-05-16T10:30:00.001Z
 ---
 
 # An h1 header

--- a/packages/core/src/providers/md/index.ts
+++ b/packages/core/src/providers/md/index.ts
@@ -63,16 +63,22 @@ export class Markdown implements IFileProvider<MarkdownSettings> {
       );
       note.pinned = frontmatter.pinned;
       note.favorite = frontmatter.favorite;
-      note.dateCreated = getPropertyWithFallbacks(
+      const dateCreated = getPropertyWithFallbacks(
         frontmatter,
         ["created", "created_at", "date created"],
         note.dateCreated
       );
-      note.dateEdited = getPropertyWithFallbacks(
+      if (dateCreated !== undefined) {
+        note.dateCreated = new Date(dateCreated).getTime();
+      }
+      const dateEdited = getPropertyWithFallbacks(
         frontmatter,
         ["updated", "updated_at", "date updated"],
         note.dateEdited
       );
+      if (dateEdited !== undefined) {
+        note.dateEdited = new Date(dateEdited).getTime();
+      }
       note.color = frontmatter.color;
     }
     yield { type: "note", note };


### PR DESCRIPTION
When importing markdown notes with frontmatter, Notesnook shows `NaN` when trying to group by dates.  As reported in https://github.com/streetwriters/notesnook/issues/4730, https://github.com/streetwriters/notesnook/issues/6191, https://github.com/streetwriters/notesnook/issues/6337, https://github.com/streetwriters/notesnook/issues/6668 and https://github.com/streetwriters/notesnook-importer/issues/45

As far as I can see the `note` variable in `packages/core/src/provider/md/index.ts`  expects a number for both `dateEdited` and `dateCreated` properties. 
It tries to fetch the data from the frontmatter info, but there it seems to be in string format (e.g. `2013-06-06T09:00:00.001Z`)

Creating a Date-object from this and getting the timestamp from that could fix the issue I think.


I have found the `__tests__/data/md/md-with-frontmatter.md` file where I added the dates, but it is not clear to me if that is automatically loaded in some test or not (yet)?